### PR TITLE
test: update Results. address pep8 complaint.

### DIFF
--- a/svgcheck/Results/version.out
+++ b/svgcheck/Results/version.out
@@ -1,2 +1,2 @@
 svgcheck = 0.6.0
-rfctools_common = 0.6.1
+rfctools_common = 0.6.2

--- a/svgcheck/test.py
+++ b/svgcheck/test.py
@@ -274,8 +274,8 @@ def check_results(file1, file2Name):
     result = list(d.compare(lines1, lines2))
 
     hasError = False
-    for l in result:
-        if l[0:2] == '+ ' or l[0:2] == '- ':
+    for line in result:
+        if line[0:2] == '+ ' or line[0:2] == '- ':
             hasError = True
             break
 
@@ -317,8 +317,8 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
         result = list(d.compare(lines1, lines2))
 
         hasError = False
-        for l in result:
-            if l[0:2] == '+ ' or l[0:2] == '- ':
+        for line in result:
+            if line[0:2] == '+ ' or line[0:2] == '- ':
                 hasError = True
                 break
         if hasError:
@@ -344,8 +344,8 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
         result = list(d.compare(lines1, lines2))
 
         hasError = False
-        for l in result:
-            if l[0:2] == '+ ' or l[0:2] == '- ':
+        for line in result:
+            if line[0:2] == '+ ' or line[0:2] == '- ':
                 hasError = True
                 break
         if hasError:
@@ -364,8 +364,8 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
         result = list(d.compare(lines1, lines2))
 
         hasError = False
-        for l in result:
-            if l[0:2] == '+ ' or l[0:2] == '- ':
+        for line in result:
+            if line[0:2] == '+ ' or line[0:2] == '- ':
                 hasError = True
                 break
 


### PR DESCRIPTION
Having the output of version captured in source-control this way is strange - premise of test needs to be reconsidered. Perhaps the essence would be addressed by moving to using constraints.txt, and then comparing the --version output against what that contains.