### PR TITLE
feat: Remove command line option --no-xinclude

### DIFF
--- a/svgcheck/run.py
+++ b/svgcheck/run.py
@@ -38,8 +38,6 @@ def main():
     parser_options = optparse.OptionGroup(optionparser, 'Parser Options')
     parser_options.add_option('-N', '--no-network', action='store_true', default=False,
                               help='don\'t use the network to resolve references')
-    parser_options.add_option('-X', "--no-xinclude", action='store_true', default=False,
-                              help='don\'t resolve xi:include elements')
 
     parser_options.add_option('-C', '--clear-cache', action='store_true', dest='clear_cache',
                               default=False, help='purge the cache and exit')

--- a/svgcheck/test.py
+++ b/svgcheck/test.py
@@ -117,22 +117,22 @@ class TestParserMethods(unittest.TestCase):
                       "Results/rfc-01.xml", "Temp/rfc.xml")
 
     def test_to_stdout(self):
-        check_process(self, [sys.executable, test_program, "--repair", "--no-xinclude",
+        check_process(self, [sys.executable, test_program, "--repair",
                              "Tests/rfc.xml"], "Results/rfc-02.out", "Results/rfc-02.err",
                       None, None)
 
     def test_always_to_stdout(self):
-        check_process(self, [sys.executable, test_program, "--always-emit", "--no-xinclude",
+        check_process(self, [sys.executable, test_program, "--always-emit",
                              "Tests/good.svg"], "Results/colors.out", "Results/good.err",
                       None, None)
 
     def test_always2_to_stdout(self):
-        check_process(self, [sys.executable, test_program, "--always-emit", "--no-xinclude",
+        check_process(self, [sys.executable, test_program, "--always-emit",
                              "Tests/colors.svg"], "Results/colors.out", "Results/colors.err",
                       None, None)
 
     def test_to_quiet(self):
-        check_process(self, [sys.executable, test_program, "--no-xinclude", "--quiet",
+        check_process(self, [sys.executable, test_program, "--quiet",
                              "Tests/rfc.xml"], "Results/rfc-03.out",
                       "Results/rfc-03.err", None, None)
 


### PR DESCRIPTION
Command line option `--no-xinclude` has no effect since the move to xml2rfc from rfctools-common.