### PR TITLE
fix: remove douplicate key

### DIFF
--- a/svgcheck/word_properties.py
+++ b/svgcheck/word_properties.py
@@ -176,8 +176,6 @@ properties = {
     'fill-rule':           ('nonzero', 'evenodd', 'inherit'),
     'fill-opacity':        (),  # 'inherit'
 
-    'height':              ('<number>',),
-
     'requiredFeatures': (),
     'requiredFormats': (),
     'requiredExtensions': (),


### PR DESCRIPTION
`height` was available twice.