### PR TITLE
chore remove py2 code

### DIFF
--- a/svgcheck/checksvg.py
+++ b/svgcheck/checksvg.py
@@ -134,7 +134,7 @@ def value_ok(obj, v):
         else:
             shade = 0
 
-        log.note(u"Color or grayscale heuristic applied to: '{0}' yields shade: '{1}'".
+        log.note("Color or grayscale heuristic applied to: '{0}' yields shade: '{1}'".
                  format(v, shade))
         if shade > wp.color_threshold:
             return (False, 'white')
@@ -236,12 +236,12 @@ def check(el, depth=0):
                     errorCount += 1
                     if new_val is not None:
                         el.attrib[attr] = new_val
-                        log.warn(u"The attribute '{1}' does not allow the value '{0}',"
-                                 u" replaced with '{2}'".format(val, attr, new_val), where=el)
+                        log.warn("The attribute '{1}' does not allow the value '{0}',"
+                                 " replaced with '{2}'".format(val, attr, new_val), where=el)
                     else:
                         attribs_to_remove.append(nsAttrib)
-                        log.warn(u"The attribute '{1}' does not allow the value '{0}',"
-                                 u" attribute to be removed".format(val, attr), where=el)
+                        log.warn("The attribute '{1}' does not allow the value '{0}',"
+                                 " attribute to be removed".format(val, attr), where=el)
 
     for attrib in attribs_to_remove:
         del el.attrib[attrib]

--- a/svgcheck/log.py
+++ b/svgcheck/log.py
@@ -81,7 +81,7 @@ def error(*args, **kwargs):
     if 'additional' in kwargs:
         prefix = ' ' * kwargs['additional']
 
-    write_err.write(prefix + u' '.join(args))
+    write_err.write(prefix + ' '.join(args))
     write_err.write('\n')
     write_err.flush()
 

--- a/svgcheck/test.py
+++ b/svgcheck/test.py
@@ -219,7 +219,7 @@ def check_results(file1, file2Name):
          any differences
     """
 
-    with io.open(file2Name, 'r', encoding='utf-8') as f:
+    with open(file2Name, encoding='utf-8') as f:
         lines2 = f.readlines()
 
     if os.name == 'nt' and (file2Name.endswith(".out") or file2Name.endswith(".err")):
@@ -264,7 +264,7 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
 
     returnValue = True
     if stdoutFile is not None:
-        with io.open(stdoutFile, 'r', encoding='utf-8') as f:
+        with open(stdoutFile, encoding='utf-8') as f:
             lines2 = f.readlines()
 
         lines1 = stdoutX.decode('utf-8').splitlines(True)
@@ -288,7 +288,7 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
             returnValue = False
 
     if errFile is not None:
-        with io.open(errFile, 'r', encoding='utf-8') as f:
+        with open(errFile, encoding='utf-8') as f:
             lines2 = f.readlines()
 
         lines1 = stderr.decode('utf-8').splitlines(True)
@@ -312,10 +312,10 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
             returnValue = False
 
     if generatedFile is not None:
-        with io.open(generatedFile, 'r', encoding='utf-8') as f:
+        with open(generatedFile, encoding='utf-8') as f:
             lines2 = f.readlines()
 
-        with io.open(compareFile, 'r', encoding='utf-8') as f:
+        with open(compareFile, encoding='utf-8') as f:
             lines1 = f.readlines()
 
         d = difflib.Differ()

--- a/svgcheck/test.py
+++ b/svgcheck/test.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import lxml.etree
 import subprocess
-import six
 import sys
 from xml2rfc.parser import XmlRfcParser
 import difflib
@@ -46,9 +45,8 @@ class Test_Coding(unittest.TestCase):
         (stdoutX, stderrX) = p.communicate()
         ret = p.wait()
         if ret > 0:
-            if six.PY3:
-                stdoutX = stdoutX.decode('utf-8')
-                stderrX = stderrX.decode('utf-8')
+            stdoutX = stdoutX.decode('utf-8')
+            stderrX = stderrX.decode('utf-8')
             print(stdoutX)
             print(stderrX)
             self.assertEqual(ret, 0)
@@ -269,10 +267,7 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
         with io.open(stdoutFile, 'r', encoding='utf-8') as f:
             lines2 = f.readlines()
 
-        if six.PY2:
-            lines1 = stdoutX.decode('utf-8').splitlines(True)
-        else:
-            lines1 = stdoutX.decode('utf-8').splitlines(True)
+        lines1 = stdoutX.decode('utf-8').splitlines(True)
 
         if os.name == 'nt':
             lines2 = [line.replace('Tests/', 'Tests\\').replace('Temp/', 'Temp\\')
@@ -296,10 +291,7 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
         with io.open(errFile, 'r', encoding='utf-8') as f:
             lines2 = f.readlines()
 
-        if six.PY2:
-            lines1 = stderr.decode('utf-8').splitlines(True)
-        else:
-            lines1 = stderr.decode('utf-8').splitlines(True)
+        lines1 = stderr.decode('utf-8').splitlines(True)
 
         if os.name == 'nt':
             lines2 = [line.replace('Tests/', 'Tests\\').replace('Temp/', 'Temp\\')

--- a/svgcheck/test.py
+++ b/svgcheck/test.py
@@ -284,7 +284,7 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
                 break
         if hasError:
             print("stdout:")
-            print(u"".join(result))
+            print("".join(result))
             returnValue = False
 
     if errFile is not None:
@@ -329,7 +329,7 @@ def check_process(tester, args, stdoutFile, errFile, generatedFile, compareFile)
 
         if hasError:
             print(generatedFile)
-            print(u"".join(result))
+            print("".join(result))
             returnValue = False
 
     tester.assertTrue(returnValue, "Comparisons failed")


### PR DESCRIPTION
There are some leftovers from python 2 code, e.g. dependency on `six` which was already removed in  #29 .